### PR TITLE
Bump required RPC server API version to prevent hang.

### DIFF
--- a/Paymetheus.Rpc/WalletClient.cs
+++ b/Paymetheus.Rpc/WalletClient.cs
@@ -21,7 +21,7 @@ namespace Paymetheus.Rpc
 {
     public sealed class WalletClient : IDisposable
     {
-        private static readonly SemanticVersion RequiredRpcServerVersion = new SemanticVersion(2, 0, 0);
+        private static readonly SemanticVersion RequiredRpcServerVersion = new SemanticVersion(2, 0, 2);
 
         public static void Initialize()
         {

--- a/Paymetheus/ViewModels/StartupWizard.cs
+++ b/Paymetheus/ViewModels/StartupWizard.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2016 The Decred developers
 // Licensed under the ISC license.  See LICENSE file in the project root for full license information.
 
+using Grpc.Core;
 using Paymetheus.Decred;
 using Paymetheus.Decred.Util;
 using Paymetheus.Decred.Wallet;
@@ -337,11 +338,13 @@ namespace Paymetheus.ViewModels
                 await App.Current.Synchronizer.WalletRpcClient.OpenWallet(PublicPassphrase);
                 Wizard.OnFinished();
             }
-            catch (Exception ex) when (ErrorHandling.IsClientError(ex))
+            catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.InvalidArgument)
             {
-                MessageBox.Show("Public data decryption was unsuccessful");
+                MessageBox.Show("Incorrect passphrase");
+            }
+            catch (Exception ex)
+            {
                 MessageBox.Show(ex.ToString());
-                return;
             }
             finally
             {


### PR DESCRIPTION
While here, improve error messages for when an incorrect public
passphrase is used during wallet opening.

Fixes #8.
