### PR TITLE
Fix errors in fee estimation.

### DIFF
--- a/Paymetheus.Decred/Wallet/TransactionAuthor.cs
+++ b/Paymetheus.Decred/Wallet/TransactionAuthor.cs
@@ -62,7 +62,7 @@ namespace Paymetheus.Decred.Wallet
 
                 var maxSignedSize = Transaction.EstimateSerializeSize(inputs.Length, outputs, true);
                 var maxRequiredFee = TransactionFees.FeeForSerializeSize(feePerKb, maxSignedSize);
-                var remainingAmount = inputAmount - maxRequiredFee;
+                var remainingAmount = inputAmount - targetAmount;
                 if (remainingAmount < maxRequiredFee)
                 {
                     targetFee = maxRequiredFee;
@@ -70,7 +70,7 @@ namespace Paymetheus.Decred.Wallet
                 }
 
                 var unsignedTransaction = new Transaction(Transaction.SupportedVersion, inputs, outputs, 0, 0);
-                var changeAmount = inputAmount - targetAmount - targetFee;
+                var changeAmount = inputAmount - targetAmount - maxRequiredFee;
                 if (changeAmount != 0 && !TransactionRules.IsDustAmount(changeAmount, Transaction.PayToPubKeyHashPkScriptSize, feePerKb))
                 {
                     var changeScript = await fetchChangeAsync();


### PR DESCRIPTION
It was possible that the actual fee added to the transaction did not
consider all of the inputs and outputs.  Use the calculated maximum
fee instead of the original target.
