### PR TITLE
Double check passphrases entered 

### DIFF
--- a/Paymetheus/App.xaml
+++ b/Paymetheus/App.xaml
@@ -46,6 +46,13 @@
             <Setter Property="FontFamily" Value="Segoe UI"/>
         </Style>
 
+        <Style x:Key="subHeaderTextBlockStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="TextAlignment" Value="Left"/>
+            <Setter Property="FontFamily" Value="Segoe UI"/>
+        </Style>
+
         <Style x:Key="connectHeaderTextBlockStyle" TargetType="TextBlock">
             <Setter Property="FontSize" Value="22"/>
             <Setter Property="Foreground" Value="#FF132F4B"/>

--- a/Paymetheus/CreateOrImportSeedView.xaml
+++ b/Paymetheus/CreateOrImportSeedView.xaml
@@ -98,7 +98,7 @@
                     Under no circumstances should this seed ever be revealed to someone else.
                     To help avoid permanent loss of your wallet, the seed <Run FontWeight="Bold" Text="must"></Run> be stored or backed up before continuing.
             </TextBlock>
-            <TextBlock Text="Write down the following seed and save it in a secure location." Foreground="White" Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Grid.Row="3" Grid.Column="1" TextWrapping="Wrap" TextAlignment="left" Width="480" Padding="0 5 0 2"/>
+            <TextBlock Text="Write down the following seed and save it in a secure location." Foreground="#ff2ed8a3" Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Grid.Row="3" Grid.Column="1" TextWrapping="Wrap" TextAlignment="left" Width="480" Padding="0 5 0 2"/>
             <Border Grid.Row="4" Grid.Column="1" CornerRadius="5" Background="#FFF4F4F5" Padding="0 4 0 8" Width="480">
                 <TextBlock Grid.Row="4" Grid.Column="1" Margin="0 0 0 0" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap" Width="460"
                            Text="{Binding Bip0032SeedWordList}"

--- a/Paymetheus/PromptPassphrasesView.xaml
+++ b/Paymetheus/PromptPassphrasesView.xaml
@@ -9,52 +9,62 @@
              d:DesignWidth="1050" 
              d:DesignHeight="680">
     <Grid x:Name="LayoutRoot">
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Height="380" Width="480" >
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="40" />
-                </Grid.RowDefinitions>
-                <TextBlock Name="EncryptWalletTextBlock" Text="Encrypt Wallet" VerticalAlignment="Top" HorizontalAlignment="Left" Width="480" Height="50" Grid.Row="2" Style="{StaticResource mediumHeaderTextBlockStyle}"/>
-            </Grid>
-            <TextBlock Name="PrivatePassphraseTextBlock" Text="Private passphrase" Foreground="White" Style="{StaticResource defaultInfoTextLightTextBlockStyle}"/>
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Height="495" Width="480" >
+            <TextBlock Name="EncryptWalletTextBlock" Text="Encrypt Wallet" VerticalAlignment="Top" HorizontalAlignment="Left" Width="480" Height="50" Grid.Row="2" Style="{StaticResource mediumHeaderTextBlockStyle}"/>
+            <TextBlock Text="Private Passphrase" Style="{StaticResource subHeaderTextBlockStyle}"  Margin="0 0 0 -10"/>
+            <TextBlock Style="{StaticResource defaultInfoTextLightTextBlockStyle}" VerticalAlignment="Top" Width="480" Margin="0 -5 0 5">
+                    <LineBreak/>
+                    The private passphrase is used to encrypt and protect the private keys in the wallet. This password 
+                    will be required to be entered whenever the user wants to send coins or sign transactions. This is 
+                    mandatory for all wallets.
+            </TextBlock>
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="59*" />
-                    <ColumnDefinition Width="70*"/>
-                    <ColumnDefinition Width="571*"/>
+                    <ColumnDefinition Width="80" />
+                    <ColumnDefinition Width="400"/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="10" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="25" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="25" />
                 </Grid.RowDefinitions>
-                <Rectangle Fill="#FFF4F4F5" RadiusY="5" RadiusX="5" Height="25" VerticalAlignment="Bottom" Grid.Row="1" Grid.ColumnSpan="3"/>
-                <PasswordBox x:Name="TextBoxPrivatePassphrase"  Margin="6 2" Padding="2" Background="{x:Null}" BorderThickness="0" PasswordChanged="TextBoxPrivatePassphrase_PasswordChanged" Grid.Row="1" Grid.ColumnSpan="3"/>
+                <TextBlock Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Text="Passphrase" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"></TextBlock>
+                <Rectangle Fill="#FFF4F4F5" RadiusY="5" RadiusX="5" Height="25" VerticalAlignment="Bottom" Grid.Row="1" Grid.Column="1"/>
+                <PasswordBox x:Name="TextBoxPrivatePassphrase"  Margin="4 2" Padding="2" Background="{x:Null}" BorderThickness="0" PasswordChanged="TextBoxPrivatePassphrase_PasswordChanged" Grid.Row="1" Grid.Column="1" ToolTip="Passphrase"/>
+                <TextBlock Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Text="Confirm" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"></TextBlock>
+                <Rectangle Fill="#FFF4F4F5" RadiusY="5" RadiusX="5" Height="25"  VerticalAlignment="Bottom" Grid.Row="3" Grid.Column="1"/>
+                <PasswordBox x:Name="TextBoxPrivatePassphraseConfirm"   Margin="4 2" Padding="2" Background="{x:Null}" BorderThickness="0" PasswordChanged="TextBoxPrivatePassphraseConfirm_PasswordChanged" Grid.Row="3" Grid.Column="1" ToolTip="Confirm passphrase"/>
             </Grid>
-            <Label Grid.Column="0"  Margin="0 45 0 2">
-                <TextBlock TextWrapping="Wrap" HorizontalAlignment="Left" Width="480" Margin="-5 -5 0 5" Foreground="#FFB7D1F0">
-                    <Run Text="OPTIONAL" FontSize="16" FontWeight="Bold"></Run>
+            <TextBlock Text="Public Passphrase (Optional)" Style="{StaticResource subHeaderTextBlockStyle}"  Margin="0 20 0 0"/>
+            <TextBlock Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Width="480" Margin="0 -15 0 10">
                     <LineBreak/>
-                    Public encryption encrypts public keys and other data that is
+                    The public passphrase encrypts public keys and other data that is
                     made public on the blockchain.
                     Enabling public encryption increases privacy in case of a compromised wallet
                     file, but requires entering the public encryption passphrase before the
                     wallet can be opened.
                     Private keys are always encrypted regardless of whether public encryption
-                    is used, and a compromised wallet file cannot be spent from
+                    is used, and a compromised wallet file cannot be spent from.
                 </TextBlock>
-            </Label>
-            <CheckBox Foreground="White" Content="Encrypt public data" IsChecked="{Binding UsePublicEncryption}" Margin="6 2"/>
-            <TextBlock Name="PublicPassphraseTextBlock" Text="Public passphrase" Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Foreground="White" Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}"/>
+                <CheckBox Foreground="White" Content=" Encrypt public data" FontFamily="Segoe UI" IsChecked="{Binding UsePublicEncryption}" Margin="6 0 0 6" Padding="0 0 0 0"/>
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="80"/>
+                    <ColumnDefinition Width="400"/>
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="10" />
-                    <RowDefinition Height="*" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="25" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="25" />
                 </Grid.RowDefinitions>
-                <Rectangle Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Fill="#FFF4F4F5" Margin="0,0,0,0.449" RadiusY="5" RadiusX="5" Height="25" VerticalAlignment="Bottom" Grid.Row="2"/>
-                <PasswordBox x:Name="TextBoxPublicPassphrase" Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Margin="6 2" Padding="2" Background="{x:Null}" BorderThickness="0"  Grid.Row="2" PasswordChanged="TextBoxPublicPassphrase_PasswordChanged"/>
+                <TextBlock Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Text="Passphrase" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center"></TextBlock>
+                <Rectangle Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Fill="#FFF4F4F5" Margin="0,0,0,0.449" RadiusY="5" RadiusX="5" Height="25" VerticalAlignment="Bottom" Grid.Row="1" Grid.Column="1" ToolTip="Passphrase"/>
+                <PasswordBox x:Name="TextBoxPublicPassphrase" Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Margin="4 2" Padding="2" Background="{x:Null}" BorderThickness="0"  Grid.Row="1" Grid.Column="1" PasswordChanged="TextBoxPublicPassphrase_PasswordChanged"/>
+                <TextBlock Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Style="{StaticResource defaultInfoTextLightTextBlockStyle}" Text="Confirm" Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"></TextBlock>
+                <Rectangle Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Fill="#FFF4F4F5" Margin="0,0,0,0.449" RadiusY="5" RadiusX="5" Height="25" VerticalAlignment="Bottom" Grid.Row="3" Grid.Column="1" ToolTip="Confirm passphrase"/>
+                <PasswordBox x:Name="TextBoxPublicPassphraseConfirm" Visibility="{Binding UsePublicEncryption, Converter={StaticResource hiddenConverter}}" Margin="4 2" Padding="2" Background="{x:Null}" BorderThickness="0"  Grid.Row="3" Grid.Column="1" PasswordChanged="TextBoxPublicPassphraseConfirm_PasswordChanged"/>
             </Grid>
             <Button Content="ENCRYPT" Command="{Binding CreateWalletCommand}" HorizontalAlignment="Center" Height="35.5" Margin="0 10 0 0" VerticalAlignment="Top" Width="123" Style="{DynamicResource ButtonBlue}" Foreground="#FF132F4B" Grid.Row="4"/>
         </StackPanel>

--- a/Paymetheus/PromptPassphrasesView.xaml.cs
+++ b/Paymetheus/PromptPassphrasesView.xaml.cs
@@ -36,12 +36,26 @@ namespace Paymetheus
                 ((dynamic)DataContext).PrivatePassphrase = ((PasswordBox)sender).Password;
             }
         }
+        private void TextBoxPrivatePassphraseConfirm_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (DataContext != null)
+            {
+                ((dynamic)DataContext).PrivatePassphraseConfirm = ((PasswordBox)sender).Password;
+            }
+        }
 
         private void TextBoxPublicPassphrase_PasswordChanged(object sender, RoutedEventArgs e)
         {
             if (DataContext != null)
             {
                 ((dynamic)DataContext).PublicPassphrase = ((PasswordBox)sender).Password;
+            }
+        }
+        private void TextBoxPublicPassphraseConfirm_PasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (DataContext != null)
+            {
+                ((dynamic)DataContext).PublicPassphraseConfirm = ((PasswordBox)sender).Password;
             }
         }
     }

--- a/Paymetheus/ViewModels/StartupWizard.cs
+++ b/Paymetheus/ViewModels/StartupWizard.cs
@@ -304,7 +304,9 @@ namespace Paymetheus.ViewModels
             set { _usePublicEncryption = value; RaisePropertyChanged(); }
         }
         public string PublicPassphrase { private get; set; } = "";
+        public string PublicPassphraseConfirm { private get; set; } = "";
         public string PrivatePassphrase { private get; set; } = "";
+        public string PrivatePassphraseConfirm { private get; set; } = "";
 
         public DelegateCommand CreateWalletCommand { get; }
         private async void CreateWallet()
@@ -318,6 +320,16 @@ namespace Paymetheus.ViewModels
                     MessageBox.Show("Private passphrase is required");
                     return;
                 }
+                if (string.IsNullOrEmpty(PrivatePassphraseConfirm))
+                {
+                    MessageBox.Show("Confirm private passphrase");
+                    return;
+                }
+                if (!string.Equals(PrivatePassphrase, PrivatePassphraseConfirm))
+                {
+                    MessageBox.Show("Private passphrases do not match");
+                    return;
+                }
 
                 var publicPassphrase = PublicPassphrase;
                 if (!UsePublicEncryption)
@@ -329,6 +341,17 @@ namespace Paymetheus.ViewModels
                     if (string.IsNullOrEmpty(publicPassphrase))
                     {
                         MessageBox.Show("Public passphrase is required");
+                        return;
+                    }
+                    if (string.IsNullOrEmpty(PublicPassphraseConfirm))
+                    {
+                        MessageBox.Show("Confirm public passphrase");
+                        return;
+                    }
+
+                    if (!string.Equals(publicPassphrase, PublicPassphraseConfirm))
+                    {
+                        MessageBox.Show("Public passphrases do not match");
                         return;
                     }
                 }


### PR DESCRIPTION
The passphrase boxes for private and public passphrases did
not ask the user to confirm their passphrases to prevent typos.
This feature has been added and the input boxes for both
passphrases labeled.

Fixes #94.
