### PR TITLE
Use full installation path for the wallet binary.

### DIFF
--- a/Paymetheus.Rpc/Paymetheus.Rpc.csproj
+++ b/Paymetheus.Rpc/Paymetheus.Rpc.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -44,6 +44,7 @@
     <Compile Include="Extensions.cs" />
     <Compile Include="Portability.cs" />
     <Compile Include="ProcessExtensions.cs" />
+    <Compile Include="ProcessNotFoundException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ErrorHandling.cs" />
     <Compile Include="SemanticVersion.cs" />

--- a/Paymetheus.Rpc/Portability.cs
+++ b/Paymetheus.Rpc/Portability.cs
@@ -37,7 +37,7 @@ namespace Paymetheus.Rpc
                         return Path.Combine(homeDirectory, ToDotLower(organization), product.ToLower());
                     }
                 default:
-                    throw new PlatformNotSupportedException($"PlatformID={platform}");
+                    throw PlatformNotSupported(platform);
             }
         }
 
@@ -60,5 +60,26 @@ namespace Paymetheus.Rpc
 
             return "." + value.ToLower();
         }
+
+        public static string ExecutableInstallationPath(PlatformID platform, string organization, string executableName)
+        {
+            // Unix and Mac: Unsure where the expected installation paths are or would be.
+            // These are staying unimplemeted until it actually matters.
+            switch (platform)
+            {
+                case PlatformID.Win32NT:
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                        ToUpper(organization), "Paymetheus", executableName.ToLower() + ".exe");
+                case PlatformID.Unix:
+                    throw new NotImplementedException();
+                case PlatformID.MacOSX:
+                    throw new NotImplementedException();
+                default:
+                    throw PlatformNotSupported(platform);
+            }
+        }
+
+        private static PlatformNotSupportedException PlatformNotSupported(PlatformID platform) =>
+            new PlatformNotSupportedException($"PlatformID={platform}");
     }
 }

--- a/Paymetheus.Rpc/ProcessNotFoundException.cs
+++ b/Paymetheus.Rpc/ProcessNotFoundException.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) 2016 The Decred developers
+// Licensed under the ISC license.  See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Paymetheus.Rpc
+{
+    public class ProcessNotFoundException : Exception
+    {
+        public ProcessNotFoundException(string processNameOrPath, Exception innerException = null)
+            : base($"The process `{processNameOrPath}` could not be started because it was not found", innerException) { }
+    }
+}

--- a/Paymetheus/App.xaml.cs
+++ b/Paymetheus/App.xaml.cs
@@ -135,7 +135,7 @@ namespace Paymetheus
 
             var syncTask = Task.Run(async () =>
             {
-                return await SynchronizerViewModel.Startup(activeNetwork, appDataDir);
+                return await SynchronizerViewModel.Startup(activeNetwork, appDataDir, args.SearchPathForWalletProcess);
             });
             var synchronizer = syncTask.Result;
 

--- a/Paymetheus/ProcessArguments.cs
+++ b/Paymetheus/ProcessArguments.cs
@@ -10,15 +10,18 @@ namespace Paymetheus
     class ProcessArguments
     {
         public BlockChainIdentity IntendedNetwork { get; }
+        public bool SearchPathForWalletProcess { get; }
 
-        private ProcessArguments(BlockChainIdentity intendedNetwork)
+        private ProcessArguments(BlockChainIdentity intendedNetwork, bool searchPathForWalletProcess)
         {
             IntendedNetwork = intendedNetwork;
+            SearchPathForWalletProcess = searchPathForWalletProcess;
         }
 
         public static ProcessArguments ParseArguments(string[] args)
         {
             var intendedNetwork = BlockChainIdentity.MainNet;
+            var searchPathForWalletProcess = false;
 
             foreach (var arg in args)
             {
@@ -27,12 +30,15 @@ namespace Paymetheus
                     case "-testnet":
                         intendedNetwork = BlockChainIdentity.TestNet;
                         break;
+                    case "-searchpath":
+                        searchPathForWalletProcess = true;
+                        break;
                     default:
                         throw new Exception($"Unrecognized argument `{arg}`");
                 }
             }
 
-            return new ProcessArguments(intendedNetwork);
+            return new ProcessArguments(intendedNetwork, searchPathForWalletProcess);
         }
     }
 }

--- a/Paymetheus/ViewModels/SynchronizerViewModel.cs
+++ b/Paymetheus/ViewModels/SynchronizerViewModel.cs
@@ -29,7 +29,7 @@ namespace Paymetheus.ViewModels
         public WalletClient WalletRpcClient { get; }
         public Wallet Wallet { get; private set; }
 
-        public static async Task<SynchronizerViewModel> Startup(BlockChainIdentity activeNetwork, string walletAppDataDir)
+        public static async Task<SynchronizerViewModel> Startup(BlockChainIdentity activeNetwork, string walletAppDataDir, bool searchPath)
         {
             // Begin the asynchronous reading of the certificate before starting the wallet
             // process.  This uses filesystem events to know when to begin reading the certificate,
@@ -37,7 +37,13 @@ namespace Paymetheus.ViewModels
             // beginning to observe the change, the event may never fire and the cert won't be read.
             var rootCertificateTask = TransportSecurity.ReadModifiedCertificateAsync(walletAppDataDir);
 
-            var walletProcess = WalletProcess.Start(activeNetwork, walletAppDataDir);
+            string walletProcessPath = null;
+            if (!searchPath)
+            {
+                walletProcessPath = Portability.ExecutableInstallationPath(
+                    Environment.OSVersion.Platform, AssemblyResources.Organization, WalletProcess.ProcessName);
+            }
+            var walletProcess = WalletProcess.Start(activeNetwork, walletAppDataDir, walletProcessPath);
 
             WalletClient walletClient;
             try


### PR DESCRIPTION
This feature can be disabled by using the -searchpath command line
argument.

Fixes #97.
