### PR TITLE
Add 33 byte checksum to seed.

### DIFF
--- a/Paymetheus.Decred/Wallet/WalletSeed.cs
+++ b/Paymetheus.Decred/Wallet/WalletSeed.cs
@@ -74,6 +74,13 @@ namespace Paymetheus.Decred.Wallet
             }
         }
 
-        public static string[] EncodeWordList(PgpWordList pgpWordList, byte[] seed) => pgpWordList.Encode(seed);
+        public static string[] EncodeWordList(PgpWordList pgpWordList, byte[] seed)
+        {
+            var seedHash = DoubleSha256(seed);
+            var seedWithChecksum = new byte[seed.Length + 1];
+            Array.Copy(seed, seedWithChecksum, seed.Length);
+            seedWithChecksum[seedWithChecksum.Length - 1] = seedHash[0];
+            return pgpWordList.Encode(seedWithChecksum);
+        }
     }
 }


### PR DESCRIPTION
This is only being done for compatibility with older dcrwallet
versions that refuse to decode word list seeds that are not 33 words
long when entering them from the console (the gRPC API accepts seeds
as simply a byte array so long as they are within the correct length
range).

Fixes #108.
