### PR TITLE
Make "add account" button nonexecutable when running.

### DIFF
--- a/Paymetheus/ViewModels/CreateAccountDialogViewModel.cs
+++ b/Paymetheus/ViewModels/CreateAccountDialogViewModel.cs
@@ -2,8 +2,10 @@
 // Copyright (c) 2016 The Decred developers
 // Licensed under the ISC license.  See LICENSE file in the project root for full license information.
 
+using Grpc.Core;
 using Paymetheus.Framework;
 using System;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 
@@ -13,7 +15,7 @@ namespace Paymetheus.ViewModels
     {
         public CreateAccountDialogViewModel(ShellViewModel shell) : base(shell)
         {
-            Execute = new DelegateCommand(ExecuteAction);
+            Execute = new DelegateCommandAsync(ExecuteAction);
         }
 
         public string AccountName { get; set; } = "";
@@ -21,16 +23,26 @@ namespace Paymetheus.ViewModels
 
         public ICommand Execute { get; }
 
-        private async void ExecuteAction()
+        private async Task ExecuteAction()
         {
             try
             {
                 await App.Current.Synchronizer.WalletRpcClient.NextAccountAsync(Passphrase, AccountName);
                 HideDialog();
             }
+            catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.AlreadyExists)
+            {
+                MessageBox.Show("Account name already exists");
+            }
+            catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.InvalidArgument)
+            {
+                // Since there is no client-side validation of account name user input, this might be an
+                // invalid account name or the wrong passphrase.  Just show the detail for now.
+                MessageBox.Show(ex.Status.Detail);
+            }
             catch (Exception ex)
             {
-                MessageBox.Show(ex.Message);
+                MessageBox.Show(ex.Message, "Error");
             }
         }
     }


### PR DESCRIPTION
Prevents double clicking the button to send the CreateAccount RPC
twice, the second time failing with errors due to already having an
account by that name.

While here, improve the error handling slightly.

Fixes #113.
