### PR TITLE
Fix calculation of transaction debit/credit amount to the wallet.

### DIFF
--- a/Paymetheus/ViewModels/TransactionViewModel.cs
+++ b/Paymetheus/ViewModels/TransactionViewModel.cs
@@ -115,14 +115,9 @@ namespace Paymetheus.ViewModels
             {
                 Amount debitCredit = 0;
                 foreach (var controlledInput in _transaction.Inputs)
-                    debitCredit += controlledInput.Amount;
+                    debitCredit -= controlledInput.Amount;
                 foreach (var controlledOutput in _transaction.Outputs.OfType<WalletTransaction.Output.ControlledOutput>())
-                {
-                    if (controlledOutput.Change)
-                        debitCredit -= controlledOutput.Amount;
-                    else
-                        debitCredit += controlledOutput.Amount;
-                }
+                    debitCredit += controlledOutput.Amount;
                 return debitCredit;
             }
         }


### PR DESCRIPTION
Only consider whether a transaction output is controlled or not when
determining whether to add it as a credit.  This fixes the calculation
when transactions are sent to an external address from the same wallet
(e.g. when moving funds across accounts).

Debits should be negative and credits positive, so fix the signs.

Fixes #136.
