### PR TITLE
Protect access to the shared Wallet structure.

### DIFF
--- a/Paymetheus.Decred/Paymetheus.Decred.csproj
+++ b/Paymetheus.Decred/Paymetheus.Decred.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Errors.cs" />
     <Compile Include="Script\SignatureAlgorithm.cs" />
     <Compile Include="TransactionRules.cs" />
+    <Compile Include="Util\Mutex.cs" />
     <Compile Include="Util\Base58.cs" />
     <Compile Include="Util\ByteCursor.cs" />
     <Compile Include="EncodingException.cs" />

--- a/Paymetheus.Decred/Util/Mutex.cs
+++ b/Paymetheus.Decred/Util/Mutex.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2016 The Decred developers
+// Licensed under the ISC license.  See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Paymetheus.Decred.Util
+{
+    public sealed class Mutex<T> where T : class
+    {
+        readonly T _instance;
+        readonly SemaphoreSlim _sem = new SemaphoreSlim(1);
+
+        public Mutex(T instance)
+        {
+            _instance = instance;
+        }
+
+        public struct MutexGuard : IDisposable
+        {
+            public T Instance { get; }
+
+            readonly SemaphoreSlim _sem;
+
+            internal MutexGuard(T instance, SemaphoreSlim sem)
+            {
+                Instance = instance;
+                _sem = sem;
+            }
+
+            public void Dispose()
+            {
+                _sem?.Release();
+            }
+        }
+
+        public async Task<MutexGuard> LockAsync()
+        {
+            await _sem.WaitAsync();
+            return new MutexGuard(_instance, _sem);
+        }
+    }
+}

--- a/Paymetheus.Tests.Decred/Paymetheus.Tests.Decred.csproj
+++ b/Paymetheus.Tests.Decred/Paymetheus.Tests.Decred.csproj
@@ -75,6 +75,7 @@
     <Compile Include="TransactionTests.cs" />
     <Compile Include="Util\Base58Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\MutexTests.cs" />
     <Compile Include="Wallet\WalletSeedTests.cs" />
     <Compile Include="Wallet\AddressTests.cs" />
     <Compile Include="Wallet\ChecksumTests.cs" />

--- a/Paymetheus.Tests.Decred/Util/MutexTests.cs
+++ b/Paymetheus.Tests.Decred/Util/MutexTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2016 The Decred developers
+// Licensed under the ISC license.  See LICENSE file in the project root for full license information.
+
+using Paymetheus.Decred.Util;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Paymetheus.Tests.Decred.Util
+{
+    public static class MutexTests
+    {
+        [Fact]
+        public static void MutexProvidesExclusiveAccess()
+        {
+            var m = new Mutex<object>(null);
+            int c = 0;
+
+            var tasks = new Task[100];
+
+            for (var i = 0; i < 100; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    for (var j = 0; j < 100; j++)
+                    {
+                        using (var g = await m.LockAsync())
+                        {
+                            if (Interlocked.Increment(ref c) != 1)
+                            {
+                                throw new Exception("Counter was not 0 when lock was entered: another task is inside its critical section.");
+                            }
+                            if (Interlocked.Decrement(ref c) != 0)
+                            {
+                                throw new Exception("Counter changed while lock was entered: another task is inside its critical section.");
+                            }
+                        }
+
+                    }
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
Because both the UI thread and the wallet RPC synchronization tasks
may access the wallet structure at the same time, access to the
structure must be synchronized.  Add a new Mutex<T> type which when
unlocked, provides access to the underlying locked instance (in this
case, the Wallet).  This ensures that (unless the wallet reference is
leaked outside of the exclusive access) all access to the wallet only
occurs when the lock is held.  This is also preferable to acquiring a
private mutex in each of the Wallet's public APIs as it allows
multiple public APIs to be called without any other tasks from
changing wallet state inbetween calls.

The mutex can only be acquired asynchronously.  This ensures that the
UI thread never blocks attempting to access wallet state.

Fixes #114.
