### PR TITLE
Fix the synchronization task to wait on the next tx/block event.

### DIFF
--- a/Paymetheus.Rpc/WalletClient.cs
+++ b/Paymetheus.Rpc/WalletClient.cs
@@ -468,6 +468,7 @@ namespace Paymetheus.Rpc
                             {
                                 var changes = notifications.Buffer.Receive();
                                 w.ApplyTransactionChanges(changes);
+                                txChangesTask = notifications.Buffer.OutputAvailableAsync();
                             }
                         }
                     }


### PR DESCRIPTION
After the first transaction notifications request was processed, the
task that the top of the loop would wait on was not advanced to the
next item.  This would cause the Task.WhenAny to immediately return
the previously handled transaction notifications task.  After
acquiring the wallet mutex, the task would then block waiting for the
next item in the buffer (which may not exist yet).  This would end up
blocking the UI from accessing the wallet for siginificat periods of
time (until the next block or transaction is notified) and also block
any outstanding account notifications from being handled.
