### PR TITLE
Avoid crash after importing a script.

### DIFF
--- a/Paymetheus.Decred/Wallet/Wallet.cs
+++ b/Paymetheus.Decred/Wallet/Wallet.cs
@@ -29,7 +29,7 @@ namespace Paymetheus.Decred.Wallet
         /// </summary>
         public const int MinRecentTransactions = 10;
 
-        private const uint ImportedAccountNumber = 2147483647; // 2**31 - 1 
+        public const uint ImportedAccountNumber = 2147483647; // 2**31 - 1
 
         public Wallet(BlockChainIdentity activeChain, TransactionSet txSet, List<AccountProperties> bip0032Accounts,
             AccountProperties importedAccount, BlockIdentity chainTip)

--- a/Paymetheus/ViewModels/SynchronizerViewModel.cs
+++ b/Paymetheus/ViewModels/SynchronizerViewModel.cs
@@ -276,7 +276,7 @@ namespace Paymetheus.ViewModels
 
             // TODO: this would be better if all new accounts were a field in the event message.
             var newAccounts = e.ModifiedAccountProperties.
-                Where(kvp => kvp.Key.AccountNumber >= Accounts.Count).
+                Where(kvp => kvp.Key.AccountNumber >= Accounts.Count && kvp.Key.AccountNumber != Wallet.ImportedAccountNumber).
                 OrderBy(kvp => kvp.Key.AccountNumber);
             foreach (var modifiedAccount in newAccounts)
             {


### PR DESCRIPTION
The imported "account" is not tracked and balances can not be created
for it.  Avoid doing so and prevent an out of bounds exception when an
account changed event is received for it.
