### PR TITLE
Do not ignore errors when starting dcrd.

### DIFF
--- a/Launcher/App.xaml.cs
+++ b/Launcher/App.xaml.cs
@@ -87,6 +87,20 @@ namespace Launcher
             _consensusServerProcess?.KillIfExecuting();
         }
 
+        public void ExitIfFailed(Task t)
+        {
+            if (t.Exception != null)
+            {
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    MainWindow.Hide();
+                    MessageBox.Show(t.Exception.ToString());
+                    UncleanShutdown();
+                    Shutdown(1);
+                });
+            }
+        }
+
         public void LaunchConcensusServer(out AnonymousPipeServerStream rx, out AnonymousPipeServerStream tx)
         {
             if (Interlocked.Exchange(ref _consensusServerStarted, 1) != 0)

--- a/Launcher/ViewModels/LauncherProgressViewModel.cs
+++ b/Launcher/ViewModels/LauncherProgressViewModel.cs
@@ -28,7 +28,7 @@ namespace Launcher.ViewModels
             {
                 App.Current.LaunchConcensusServer(out rxPipe, out txPipe);
                 await HandleLifetimeEvents();
-            });
+            }).ContinueWith(App.Current.ExitIfFailed);
         }
 
         AnonymousPipeServerStream rxPipe = null, txPipe = null;


### PR DESCRIPTION
Add a new function to the App class that can be reused by other
started Tasks where errors should also result in an error message and
application exit.

Fixes #175
