### PR TITLE
Be backwards compatible with v1 API pools.

### DIFF
--- a/Paymetheus.StakePoolIntegration/PoolUserInfo.cs
+++ b/Paymetheus.StakePoolIntegration/PoolUserInfo.cs
@@ -24,11 +24,9 @@ namespace Paymetheus.StakePoolIntegration
         [JsonProperty(PropertyName = "TicketAddress")]
         public string VotingAddress { get; set; }
 
-        [JsonRequired]
         [JsonProperty(PropertyName = "VoteBits")]
         public ushort VoteBits { get; set; }
 
-        [JsonRequired]
         [JsonProperty(PropertyName = "VoteBitsVersion")]
         public uint StakeVersion { get; set; }
     }

--- a/Paymetheus/PurchaseTickets.xaml
+++ b/Paymetheus/PurchaseTickets.xaml
@@ -133,7 +133,7 @@
 
             <TextBox Text="{Binding ResponseString, Mode=TwoWay}" Foreground="#FF0C1E3E" FontSize="16" Margin="0 40 0 0" Background="Transparent" BorderThickness="0" IsReadOnly="True" TextWrapping="Wrap"/>
 
-            <StackPanel Visibility="{Binding VotePreferencesVisibility, Mode=OneTime}">
+            <StackPanel Visibility="{Binding VotePreferencesVisibility, Mode=OneWay}">
                 <StackPanel.Resources>
                     <DataTemplate x:Key="AgendaChoiceTemplate">
                         <Grid x:Name="ItemGrid" Width="540" Margin="0 0 0 12" HorizontalAlignment="Left">

--- a/Paymetheus/ViewModels/ManageStakePoolsDialogViewModel.cs
+++ b/Paymetheus/ViewModels/ManageStakePoolsDialogViewModel.cs
@@ -51,7 +51,7 @@ namespace Paymetheus.ViewModels
                 .Where(p => p.ApiEnabled)
                 .Where(p => p.Uri.Scheme == "https")
                 .Where(p => p.Network == App.Current.ActiveNetwork.Name)
-                .Where(p => p.SupportedApiVersions.Contains(PoolApiClient.Version))
+                .Where(p => p.SupportedApiVersions.Where(PoolApiClient.IsSupportedApiVersion).Any())
                 .OrderBy(p => p.Uri.Host);
 
             var selectedStakePool = availablePools.FirstOrDefault();
@@ -178,7 +178,8 @@ namespace Paymetheus.ViewModels
                 var nextAddressResponse = await App.Current.Synchronizer.WalletRpcClient.NextExternalAddressAsync(SelectedVotingAccount.Account);
                 var pubKeyAddress = nextAddressResponse.Item2;
 
-                var client = new PoolApiClient(SelectedStakePool.Uri, SelectedPoolApiKey, _httpClient);
+                var bestApiVersion = PoolApiClient.BestSupportedApiVersion(SelectedStakePool.SupportedApiVersions);
+                var client = new PoolApiClient(bestApiVersion, SelectedStakePool.Uri, SelectedPoolApiKey, _httpClient);
 
                 // Sumbit the pubkey.  In the current stakepool api version only a single pubkey can
                 // be submitted per user, so if one was already submitted, simply ignore the error.


### PR DESCRIPTION
When there are no pools advertising v2, do not show the vote
preferences.

Fixes #247 