### PR TITLE
Add checkbox to rescan for imported scripts.

### DIFF
--- a/Paymetheus/App.xaml.cs
+++ b/Paymetheus/App.xaml.cs
@@ -204,5 +204,14 @@ namespace Paymetheus
                 Synchronizer?.WalletRpcProcess?.KillIfExecuting();
             }
         }
+
+        public Action<Task> WarnIfFailed(string caption = "Error") => t =>
+        {
+            var ex = t.Exception;
+            if (ex != null)
+            {
+                MessageBox.Show(ex.InnerException.Message, caption);
+            }
+        };
     }
 }

--- a/Paymetheus/ImportScriptDialogView.xaml
+++ b/Paymetheus/ImportScriptDialogView.xaml
@@ -19,6 +19,7 @@
                 <TextBox Height="100" Width="480" Name="textBox" Margin="5 2" Padding="2"
                      Text="{Binding ScriptHexString, Mode=OneWayToSource, ValidatesOnExceptions=True}" 
                      f:AttachableProperties.UpdateSourceOnEnterProperty="TextBox.Text" TextWrapping="Wrap"/>
+                <CheckBox FontSize="14" Foreground="#FF0C1E3E" Margin="5 6 5 2" Content="Rescan" VerticalContentAlignment="Bottom" IsChecked="{Binding Rescan}" />
                 <Label Content="Private passphrase:" FontSize="14" Foreground="#FF0C1E3E"/>
                 <PasswordBox Name="passphraseTextBox" Width="480" PasswordChanged="passphraseTextBox_PasswordChanged" Margin="5 2" Padding="2"/>
             </StackPanel>

--- a/Paymetheus/ViewModels/ImportScriptDialogViewModel.cs
+++ b/Paymetheus/ViewModels/ImportScriptDialogViewModel.cs
@@ -40,13 +40,21 @@ namespace Paymetheus.ViewModels
             }        
         }
 
+        public bool Rescan { get; set; } = false;
+
         public string Passphrase { private get; set; } = "";
 
         private async Task ImportScriptAsync()
         {
             try
             {
-                await App.Current.Synchronizer.WalletRpcClient.ImportScriptAsync(_scriptBytes, false, 0, Passphrase);
+                var rpcClient = App.Current.Synchronizer.WalletRpcClient;
+                await rpcClient.ImportScriptAsync(_scriptBytes, false, 0, Passphrase);
+                if (Rescan)
+                {
+                    // TODO: hook the rescan progress somewhere so the shell viewmodel can show when the rescan is over.
+                    rpcClient.RescanFromBlockHeightAsync(0).ContinueWith(App.Current.WarnIfFailed("Script import rescan failed"));
+                }
                 HideDialog();
             }
             catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.AlreadyExists)


### PR DESCRIPTION
The rescan starts from the genesis block and occurs in the background
and continues after the dialog closes.  If there is an error, an error
message is opened, but otherwise there is no feedback about when the
rescan is complete.  Such a feature would have to be integrated into
the shell viewmodel.  For now, just make the feature available.

Fixes #186.